### PR TITLE
Add Jest setup and cn helper test

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,10 @@
         "postcss": "^8.4.35",
         "tailwindcss": "^3.4.1",
         "typescript": "^5.3.3",
-        "vite": "^5.0.0"
+        "vite": "^5.0.0",
+        "jest": "^29.7.0",
+        "ts-jest": "^29.1.1",
+        "@types/jest": "^29.5.3"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,9 @@
     "postcss": "^8.4.35",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.3.3",
-    "vite": "^5.0.0"
+    "vite": "^5.0.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "@types/jest": "^29.5.3"
   }
 }

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,0 +1,7 @@
+import { cn } from '../src/lib/utils'
+
+describe('cn helper', () => {
+  it('merges class names and resolves conflicts', () => {
+    expect(cn('p-2', 'p-4')).toBe('p-4')
+  })
+})


### PR DESCRIPTION
## Summary
- add jest, ts-jest and @types/jest as dev dependencies
- configure jest with ts-jest and alias mapping
- write simple unit test for `cn` helper

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684002d83a588332bf61be5688415086