### PR TITLE
Fix comment in SettingsPage

### DIFF
--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -53,7 +53,7 @@ const SettingsPage: React.FC = () => {
       if (data) {
           setNotificationSettings(data);
       } else {
-           // Error should be logged inside getNotificationSettings if profile missing
+           // Profile was not found or could not be created
            throw new Error("Impossible de charger ou créer les paramètres de notification.");
       }
     } catch (err: any) {


### PR DESCRIPTION
## Summary
- clean up a comment in `SettingsPage` related to missing notification profiles

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684002d7820c8332807407a7ef582bd1