### PR TITLE
Fix French wording for unarchive error

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -390,7 +390,7 @@ export const unarchiveProject = async (projectId: string): Promise<{ success: bo
     if (error) throw error;
     return { success: true };
   } catch (error) {
-    console.error('Erreur lors de la désarchivage du projet:', error);
-    return { success: false, error: error instanceof Error ? error.message : 'Erreur lors de la désarchivage du projet' };
+    console.error('Erreur lors du désarchivage du projet:', error);
+    return { success: false, error: error instanceof Error ? error.message : 'Erreur lors du désarchivage du projet' };
   }
 }; 


### PR DESCRIPTION
## Summary
- update French wording for unarchiving errors in `unarchiveProject`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684002bfda2c8332b90005d4ffb622d2